### PR TITLE
Remove OPPO Reno 13FS 5G option

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,10 +76,7 @@
       let phone = "";
       let link = "#";
 
-      if (q7.includes("resistente") || q7.includes("sol")) {
-        phone = "OPPO Reno 13FS 5G (€254,90)";
-        link = "https://www.vodafone.pt/loja/telemoveis/oppo/reno-13fs-5g.html?color=preto%20grafite&storage=512&segment=consumer&paymentType=cv";
-      } else if (q2 === "noite" || (q2 === "nitidas" && q3 !== "nao" && q4.includes("fotos"))) {
+        if (q2 === "noite" || (q2 === "nitidas" && q3 !== "nao" && q4.includes("fotos"))) {
         phone = "Honor Magic6 Lite 5G (€220)";
         link = "https://www.vodafone.pt/loja/telemoveis/honor/magic6-lite-5g.html?color=verde&storage=256&segment=consumer&paymentType=cv";
       } else if (q2 === "nitidas" && q3 === "nao") {

--- a/mariazinha-quiz.html
+++ b/mariazinha-quiz.html
@@ -76,10 +76,7 @@
       let phone = "";
       let link = "#";
 
-      if (q7.includes("resistente") || q7.includes("sol")) {
-        phone = "OPPO Reno 13FS 5G (€254,90)";
-        link = "https://www.vodafone.pt/loja/telemoveis/oppo/reno-13fs-5g.html?color=preto%20grafite&storage=512&segment=consumer&paymentType=cv";
-      } else if (q2 === "noite" || (q2 === "nitidas" && q3 !== "nao" && q4.includes("fotos"))) {
+        if (q2 === "noite" || (q2 === "nitidas" && q3 !== "nao" && q4.includes("fotos"))) {
         phone = "Honor Magic6 Lite 5G (€220)";
         link = "https://www.vodafone.pt/loja/telemoveis/honor/magic6-lite-5g.html?color=verde&storage=256&segment=consumer&paymentType=cv";
       } else if (q2 === "nitidas" && q3 === "nao") {


### PR DESCRIPTION
## Summary
- remove OPPO Reno 13FS 5G from recommendation logic in both quiz pages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68480e8730c48325aa51da37cdda4c5f